### PR TITLE
Changes to accept battery level attribute from any number of various attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Lovelace Battery Entity
 
 
@@ -70,6 +71,7 @@ resources:
 |------|------|---------|-------|---------|-------------|
 | type | string | **required** | v0.1 | | `custom:battery-entity`
 | entity | string | **required** | v0.1 | | An entity_id that has a percentage as a state.
+| attribute | string | optional | v0.2 | battery,battery_level,state | defines a list of attributes to obtain the battery level from (attributes will be checked in order separated by commas)
 | name | string | optional | v0.1 | *friendly_name* | Override the entities friendly name.
 | warning | integer | optional | v0.1 | 35 | Sets the level at which the battery icon will be shown as yellow.
 | critical | integer | optional | v0.1 | 15 | Sets the level at which the battery icon will be shown as red.
@@ -81,6 +83,32 @@ resources:
 ```yaml
 - type: custom:battery-entity
   entity: sensor.front_door_lock_battery
+  attributes: battery,battery_level,batterypercent,state
+```
+
+#### Use with [Auto Entities](https://github.com/thomasloven/lovelace-auto-entities)
+If you use Auto Entities card and want to add all of the battery & battery_level attributes automatically you can do so as follows:
+
+```yaml
+card:
+  show_header_toggle: false
+  type: entities
+entities:
+  - label: Batteries
+    type: section
+filter:
+  include:
+    - attributes:
+        battery_level: <= 100
+      options:
+        type: 'custom:battery-entity'
+    - attributes:
+        battery: <= 100
+      options:
+        type: 'custom:battery-entity'
+sort:
+  method: name
+type: 'custom:auto-entities'
 ```
 
 ## License

--- a/battery-entity.js
+++ b/battery-entity.js
@@ -45,7 +45,7 @@ class BatteryEntity extends Polymer.Element {
 				[[displayName()]]
 			</div>
 			<div class="state">
-				[[roundedState(stateObj.state)]] [[stateObj.attributes.unit_of_measurement]]
+				[[displayState(stateObj.state)]]
 			</div>
 		</div>
 		`
@@ -60,12 +60,25 @@ class BatteryEntity extends Polymer.Element {
 		};
 	}
 
+    getState() {
+        const attribs = (this._config.attribute || 'battery,battery_level,state').split(',');
+        var i;
+
+        for (i = 0; i < attribs.length; i++) {
+            if (this.stateObj.attributes[attribs[i]] != undefined) {
+                return parseInt(this.stateObj.attributes[attribs[i]], 10);
+
+            }
+        }
+        return parseInt(this.stateObj.state, 10);
+    }
+
 	setConfig(config) {
 		this._config = config;
 	}
 
-	roundedState(state) {
-		return Math.round(state);
+	displayState(state) {
+	    return Math.round(this.getState()) + ' %';
 	}
 
 	displayName() {
@@ -73,7 +86,7 @@ class BatteryEntity extends Polymer.Element {
 	}
 
 	setIcon() {
-		const state = parseInt(this.stateObj.state, 10);
+		const state = this.getState();
 		const roundedLevel = Math.round(state / 10) * 10;
 		switch (roundedLevel) {
 			case 100:
@@ -88,7 +101,7 @@ class BatteryEntity extends Polymer.Element {
 	}
 
 	setColor() {
-		const state = parseInt(this.stateObj.state, 10);
+	    const state = this.getState();
 		const warningLevel = this._config.warning || 35;
 		const criticalLevel = this._config.critical || 15;
 


### PR DESCRIPTION
This was taken from the release 0.1.
I realise that there are new commits that do similar things (I didn't realise this at the time I made the changes).
**However I think that this version has features that are an improvement over the latest commit**, as you can specify the attributes that can be used (I have a component that uses batterypercent for instance).

... Also I am not sure why GitHub is showing that basically all of battery-entity.js has changed ... TortoiseGit and VS both show otherwise.