### PR TITLE
Use non-breaking space in percentage

### DIFF
--- a/battery-entity.js
+++ b/battery-entity.js
@@ -45,7 +45,7 @@ class BatteryEntity extends Polymer.Element {
 				[[displayName()]]
 			</div>
 			<div class="state">
-				[[getBatteryLevel()]] %
+				[[getBatteryLevel()]]&nbsp;%
 			</div>
 		</div>
 		`


### PR DESCRIPTION
Prevents splitting over line

Before:
![image](https://user-images.githubusercontent.com/1885159/75093179-eb977280-557f-11ea-97cc-ee9f6c8ebff1.png)

After:
![image](https://user-images.githubusercontent.com/1885159/75093311-b6d7eb00-5580-11ea-8737-2216a3ac0c26.png)
