### PR TITLE
Change plugin name in HACS to match project

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Battery Entity Card",
+    "name": "Battery Entity",
     "content_in_root": true,
     "filename": "battery-entity.js",
     "render_readme": true


### PR DESCRIPTION
Really small change, but this plugin is an entity row, not a "card", this change aligns the plugins name in HACS to match that.

* "Battery Entity Card" -> "Battery Entity"