### PR TITLE
Fix NaN issue on sensors which return string numbers

### DIFF
--- a/battery-entity.js
+++ b/battery-entity.js
@@ -73,7 +73,7 @@ class BatteryEntity extends Polymer.Element {
 		if (this.stateObj.attributes.battery) batteryValue = this.stateObj.attributes.battery;
 		if (this.stateObj.attributes.battery_level) batteryValue = this.stateObj.attributes.battery_level;
 		return Number.isFinite(parseInt(batteryValue))
-			? parseInt(Math.round(batteryValue), 10)
+			? parseInt(Math.round(parseInt(batteryValue)), 10)
 			: 0;
 	}
 


### PR DESCRIPTION
Had a couple of sensors which return "100%", which means Math.round() returns NaN.